### PR TITLE
Add msg to conform to ROS standard for topics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/Collisions.srv"
   "srv/AddObject.srv"
   "srv/RemoveObject.srv"
+  "msg/ObjectParameters.msg"
   DEPENDENCIES geometry_msgs sensor_msgs# Add packages that above messages depend on, in this case geometry_msgs for AddObject.srv
 )
 

--- a/msg/ObjectParameters.msg
+++ b/msg/ObjectParameters.msg
@@ -1,0 +1,8 @@
+# Request fields
+int8 type
+string name
+# Only used for mesh objects, file path must be absolute
+string mesh_file_path ""
+geometry_msgs/Pose pose
+geometry_msgs/Vector3 dimensions
+std_msgs/ColorRGBA color


### PR DESCRIPTION
Used to transfer info from the panel to the display via publisher-subscriber instead of using AddObject_Request, which isn't conform to ros standards.